### PR TITLE
Fix NaN for blank inputs and make background blue

### DIFF
--- a/script.js
+++ b/script.js
@@ -33,9 +33,9 @@ function updateAbsenteeismDisplay() {
 }
 
 function calculateAndUpdate() {
-    const salary = parseInt(document.getElementById('salary').value);
-    const employees = parseInt(document.getElementById('employees').value);
-    const absenteeismRate = parseFloat(document.getElementById('absenteeism').value);
+    const salary = parseInt(document.getElementById('salary').value) || 0;
+    const employees = parseInt(document.getElementById('employees').value) || 0;
+    const absenteeismRate = parseFloat(document.getElementById('absenteeism').value) || 0;
     const period = document.getElementById('period').value;
 
     const timeFactor = timeFactors[period];
@@ -64,7 +64,7 @@ function calculateAndUpdate() {
 }
 
 function updateCustomROI() {
-    const investment = parseFloat(document.getElementById('custom-investment').value);
+    const investment = parseFloat(document.getElementById('custom-investment').value) || 0;
     const roiValue = investment * 2.3;
     document.getElementById('roi-potential-custom').textContent = formatCurrency(roiValue);
 }

--- a/styles.css
+++ b/styles.css
@@ -9,7 +9,7 @@ body {
     font-family: 'Open Sans', sans-serif;
     line-height: 1.6;
     color: #333;
-    background-color: blue;
+    background-color: #fff;
 }
 
 .container {

--- a/styles.css
+++ b/styles.css
@@ -9,7 +9,7 @@ body {
     font-family: 'Open Sans', sans-serif;
     line-height: 1.6;
     color: #333;
-    background-color: #fff;
+    background-color: blue;
 }
 
 .container {


### PR DESCRIPTION
## Summary
- default numeric values to `0` when inputs are empty
- set page background color to blue

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6850a4859e4483318e88e2f43b9bd15a