### PR TITLE
Add hours lost metrics

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,6 +90,21 @@
       </div>
 
       <div class="metrics-grid">
+        <div class="metric-card">
+          <h3>Total Working Hours Lost</h3>
+          <div class="metric-value" id="hours-lost">0 h</div>
+        </div>
+        <div class="metric-card">
+          <h3>Hours Lost per Employee</h3>
+          <div class="metric-value" id="hours-lost-per-employee">0 h</div>
+        </div>
+        <div class="metric-card">
+          <h3>Average Daily Hours Lost</h3>
+          <div class="metric-value" id="daily-hours-lost">0 h</div>
+        </div>
+      </div>
+
+      <div class="metrics-grid">
         <div class="metric-card positive-impact">
           <h3>Potential Absenteeism Savings</h3>
           <div class="metric-value" id="savings-absenteeism">$0</div>

--- a/script.js
+++ b/script.js
@@ -45,10 +45,18 @@ function calculateAndUpdate() {
     const totalDaysLost = daysLostPerEmployee * employees * timeFactor;
     const dailyLoss = employees * salary * (absenteeismRate / 100) * (1 / 260);
 
+    const hoursPerDay = 8;
+    const totalHoursLost = totalDaysLost * hoursPerDay;
+    const hoursLostPerEmployee = employees > 0 ? totalHoursLost / employees : 0;
+    const avgDailyHoursLost = employees * (absenteeismRate / 100) * hoursPerDay;
+
     document.getElementById('main-loss').textContent = formatCurrency(financialLoss);
     document.getElementById('main-period').textContent = period;
     document.getElementById('days-lost').textContent = formatNumber(totalDaysLost, 1) + ' days';
     document.getElementById('daily-loss').textContent = formatCurrency(dailyLoss);
+    document.getElementById('hours-lost').textContent = formatNumber(totalHoursLost, 1) + ' h';
+    document.getElementById('hours-lost-per-employee').textContent = formatNumber(hoursLostPerEmployee, 1) + ' h';
+    document.getElementById('daily-hours-lost').textContent = formatNumber(avgDailyHoursLost, 1) + ' h';
 
     const reducedRate = absenteeismRate * 0.75;
     const reducedLoss = employees * salary * (reducedRate / 100) * timeFactor;


### PR DESCRIPTION
## Summary
- show total working hours lost, hours lost per employee, and avg daily hours lost
- compute new hour-based metrics in the JS calculations

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_6850a23405f4833189f73d5947c6ec3b